### PR TITLE
Feature/custom template delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ All those details above, the things we want to change, need to be captured in a 
     { "from": "Some Term", "to": "New Hard Coded Term" } // return "Some Term"; -> return "New Hard Coded Term";
     // ... any other replacement your project needs
   ],
-  "ignoreArtifacts": [".git", ".idea", "bin", "obj", "somefile.dll"] // usually, binary directories
+  "ignoreArtifacts": [".git", ".idea", "bin", "obj", "somefile.dll"], // usually, binary directories
+  "customDelimiters": ["<<:", ":>>"] // [optional] you can customize the delimiter to avoid interference with template files in your sample apps
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ All those details above, the things we want to change, need to be captured in a 
 
 ```javascript
 {
-  "replicantName": "NewProjectModel", // will replace {{ name }}
+  "replicantName": "NewProjectModel", // will replace <<: name :>>
   "templateName": "NexusModel", // temporary work directory
   "fileNameReplacements": [
-    { "from": "Sample", "to": "{{ name }}" } // Sample.Domain.Customer -> NewName.Domain.Customer
+    { "from": "Sample", "to": "<<: name :>>" } // Sample.Domain.Customer -> NewName.Domain.Customer
     // ... any other replacement your project needs
   ],
   "sourceCodeReplacements": [
-    { "from": "Sample", "to": "{{ name }}" }, // using Sample.Domain; -> using NewName.Domain;
-    { "from": "sample", "to": "{{ nameLowerCase }}" }, // return GetDatabase("sample"); -> return GetDatabase("newname");
-    { "from": "SAMPLE", "to": "{{ nameUpperCase }}" } // return "SAMPLE"; -> return "NEWNAME";
+    { "from": "Sample", "to": "<<: name :>>" }, // using Sample.Domain; -> using NewName.Domain;
+    { "from": "sample", "to": "<<: nameLowerCase :>>" }, // return GetDatabase("sample"); -> return GetDatabase("newname");
+    { "from": "SAMPLE", "to": "<<: nameUpperCase :>>" } // return "SAMPLE"; -> return "NEWNAME";
     { "from": "Some Term", "to": "New Hard Coded Term" } // return "Some Term"; -> return "New Hard Coded Term";
     // ... any other replacement your project needs
   ],

--- a/__tests__/cli-integration.test.ts
+++ b/__tests__/cli-integration.test.ts
@@ -226,6 +226,24 @@ describe('CLI tests', () => {
     })
   })
 
+  describe('Custom delimiter configuration', () => {
+
+    test('Should use the custom delimiter from the recipeto avoid template inception, if informed', async () => {
+      const { recipe } = await createReplicant(
+        'hello-world',
+        'helloworld-to-hithere-recipe-with-custom-delimiter.json'
+      )
+
+      let content = readTemplateFileContent(recipe, 'HelloWorld.js.ejs.t')
+      let lines = content.split('\n').map(x => x.trim())
+      expect(lines[3]).toEqual("console.log('Name = Special<!!! name !!!>')")
+
+      content = readReplicantFileContent(recipe, ['HiThere.js'])
+      lines = content.split('\n').map(x => x.trim())
+      expect(lines[3]).toEqual("console.log('Name = SpecialHiThere')")
+    })
+  })
+
   describe('Handling template files in samples should not cause inception problems', () => {
 
     test('Should copy the final project into the target directory', async () => {

--- a/src/replication/ReplicationRecipe.js
+++ b/src/replication/ReplicationRecipe.js
@@ -8,7 +8,8 @@ module.exports = class ReplicationRecipe {
     templateDir,
     fileNameReplacements,
     sourceCodeReplacements,
-    ignoreArtifacts
+    ignoreArtifacts,
+    delimiters
   ) {
     this.replicantName = replicantName
     this.templateName = templateName
@@ -16,6 +17,7 @@ module.exports = class ReplicationRecipe {
     this.fileNameReplacements = fileNameReplacements
     this.sourceCodeReplacements = sourceCodeReplacements
     this.ignoreArtifacts = ignoreArtifacts
+    this.delimiters = delimiters
   }
 
   static fromRecipeFile(recipeFilePath, replicantWorkDir) {
@@ -28,7 +30,8 @@ module.exports = class ReplicationRecipe {
       path.join(replicantWorkDir, '_templates', data.templateName),
       data.fileNameReplacements,
       data.sourceCodeReplacements,
-      data.ignoreArtifacts
+      data.ignoreArtifacts,
+      data.delimiters = data.customDelimiters || ['<<:', ':>>'] // TODO validate delimiters
     )
   }
 }

--- a/src/replication/Replicator.js
+++ b/src/replication/Replicator.js
@@ -60,7 +60,7 @@ class Replicator {
       targetPath,
       this.replicationRecipe.fileNameReplacements
     )
-    let frontmatter = ['---', `to: "{{ name }}/${targetPath}"`, '---']
+    let frontmatter = ['---', `to: "<<: name :>>/${targetPath}"`, '---'] // TODO parameterize delimiters
     await this._prepareFile(
       fullPathDest,
       frontmatter,
@@ -89,8 +89,9 @@ class Replicator {
     writeFile(filePath, adjustedContent)
 
     let contentToPrepend = metadataLines
-      .map(line => {
-        return this._replaceTermsInText(line, sourceCodeReplacements) // why?
+      .map(line => { 
+        return line
+        // return this._replaceTermsInText(line, sourceCodeReplacements) // why?
       })
       .join('\n')
     await prependToFileAsync(filePath, `${contentToPrepend}\n`)

--- a/src/replication/Replicator.js
+++ b/src/replication/Replicator.js
@@ -60,7 +60,9 @@ class Replicator {
       targetPath,
       this.replicationRecipe.fileNameReplacements
     )
-    let frontmatter = ['---', `to: "<<: name :>>/${targetPath}"`, '---'] // TODO parameterize delimiters
+
+    let delimiters = this.replicationRecipe.delimiters
+    let frontmatter = ['---', `to: "${delimiters[0]} name ${delimiters[1]}/${targetPath}"`, '---']
     await this._prepareFile(
       fullPathDest,
       frontmatter,

--- a/src/replication/replication-process.js
+++ b/src/replication/replication-process.js
@@ -19,11 +19,11 @@ const buildRecipe = replicationInstructions => {
 }
 
 const generateFileFromTemplate = (options, toolbox) => {
-  const {readFile, writeFile} = toolbox
-  const { template, target, view, directory } = options
+  const { readFile, writeFile } = toolbox
+  const { template, target, view, directory, delimiters } = options
 
   const templateContent = readFile(path.join(directory, template))
-  mustache.tags = ['<<:', ':>>']
+  mustache.tags = delimiters
   // TODO mustache.parse() ?
   var output = mustache.render(templateContent, view)
   writeFile(target, output)
@@ -52,7 +52,8 @@ const generateReplicantFromTemplate2 = async (replicator, toolbox) => {
   const {
     templateName,
     replicantName,
-    templateDir
+    templateDir,
+    delimiters
   } = replicator.replicationRecipe
   info(`Replicating sample from ${templateName}. Generating ${replicantName}.`)
 
@@ -80,7 +81,8 @@ const generateReplicantFromTemplate2 = async (replicator, toolbox) => {
         template: fileName,
         target: partialFilePath,
         view: view,
-        directory: realTemplateDir
+        directory: realTemplateDir,
+        delimiters: delimiters
       },
       toolbox
     )

--- a/src/replication/replication-process.js
+++ b/src/replication/replication-process.js
@@ -23,6 +23,8 @@ const generateFileFromTemplate = (options, toolbox) => {
   const { template, target, view, directory } = options
 
   const templateContent = readFile(path.join(directory, template))
+  mustache.tags = ['<<:', ':>>']
+  // TODO mustache.parse() ?
   var output = mustache.render(templateContent, view)
   writeFile(target, output)
 }

--- a/test-infrasctructure/fixtures/hello-world/Hello/There/World.js
+++ b/test-infrasctructure/fixtures/hello-world/Hello/There/World.js
@@ -1,2 +1,2 @@
 console.log('Hello World')
-console.log('{{ name }}...')
+console.log('<<: name :>>...')

--- a/test-infrasctructure/fixtures/helloworld-to-hithere-recipe-with-custom-delimiter.json
+++ b/test-infrasctructure/fixtures/helloworld-to-hithere-recipe-with-custom-delimiter.json
@@ -1,0 +1,16 @@
+{
+  "replicantName": "HiThere",
+  "templateName": "hi-there-generator",
+  "fileNameReplacements": [
+    { "from": "Hello", "to": "Hi" },
+    { "from": "World", "to": "There" }
+  ],
+  "sourceCodeReplacements": [
+    { "from": "Hello", "to": "Hi" },
+    { "from": "World", "to": "My People" },
+    { "from": "hello", "to": "hey" },
+    { "from": "CodeName", "to": "<!!! name !!!>" }
+  ],
+  "ignoreArtifacts": ["Bye", "Butterflies.js"],
+  "customDelimiters": ["<!!!", "!!!>"]
+}

--- a/test-infrasctructure/fixtures/helloworld-to-hithere-recipe-with-target.json
+++ b/test-infrasctructure/fixtures/helloworld-to-hithere-recipe-with-target.json
@@ -9,7 +9,7 @@
     { "from": "Hello", "to": "Hi" },
     { "from": "World", "to": "My People" },
     { "from": "hello", "to": "hey" },
-    { "from": "CodeName", "to": "{{ name }}" }
+    { "from": "CodeName", "to": "<<: name :>>" }
   ],
   "ignoreArtifacts": ["Bye", "Butterflies.js"]
 }

--- a/test-infrasctructure/fixtures/helloworld-to-hithere-recipe.json
+++ b/test-infrasctructure/fixtures/helloworld-to-hithere-recipe.json
@@ -9,7 +9,7 @@
     { "from": "Hello", "to": "Hi" },
     { "from": "World", "to": "My People" },
     { "from": "hello", "to": "hey" },
-    { "from": "CodeName", "to": "{{ name }}" }
+    { "from": "CodeName", "to": "<<: name :>>" }
   ],
   "ignoreArtifacts": ["Bye", "Butterflies.js"]
 }

--- a/test-infrasctructure/fixtures/template-incepction-recipe.json
+++ b/test-infrasctructure/fixtures/template-incepction-recipe.json
@@ -1,0 +1,12 @@
+{
+  "replicantName": "Inception",
+  "templateName": "inception-generator",
+  "fileNameReplacements": [
+    { "from": "mustache", "to": "big-mustache" }
+  ],
+  "sourceCodeReplacements": [
+    { "from": "template", "to": "file <<: nameLowerCase :>>" },
+    { "from": "insult", "to": "compliment" }    
+  ],
+  "ignoreArtifacts": []
+}

--- a/test-infrasctructure/fixtures/template-inception/template-mustache.t
+++ b/test-infrasctructure/fixtures/template-inception/template-mustache.t
@@ -1,0 +1,6 @@
+This is a {{ adjective }} template;
+
+Some insults for you:
+{{#insults}}
+ - The insult is {{.}}
+{{/insults}}


### PR DESCRIPTION
Adding the option to customize template delimiters in order to avoid unintended interference in the content of template files.
As many applications may have template files in some kind of any, allowing delimiter customization will allow users to avoid unintended interference in templates with mustache-like syntax (**{{** and **}}**).